### PR TITLE
[wip] iteration over fields_dict

### DIFF
--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -94,7 +94,7 @@ class Marshaller(ErrorStore):
         ErrorStore.__init__(self)
 
     def serialize(self, obj, fields_dict, many=False,
-                  accessor=None, dict_class=dict, index_errors=True, index=None):
+                  accessor=None, dict_class=dict, index_errors=True, index=None, iterator=iterate_fields_dict):
         """Takes raw data (a dict, list, or other object) and a dict of
         fields to output and serializes the data based on those fields.
 
@@ -132,7 +132,7 @@ class Marshaller(ErrorStore):
                 )
             return ret
         items = []
-        for attr_name, field_obj in iteritems(fields_dict):
+        for attr_name, field_obj in iterator(obj, fields_dict):
             if getattr(field_obj, 'load_only', False):
                 continue
 

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -382,6 +382,9 @@ class BaseSchema(base.SchemaABC):
         """
         return utils.get_value(obj, attr, default)
 
+    def get_marshalling_iterator(self):
+        return utils.iterate_fields_dict
+
     ##### Serialization/Deserialization API #####
 
     def dump(self, obj, many=None, update_fields=True, **kwargs):
@@ -578,6 +581,7 @@ class BaseSchema(base.SchemaABC):
                     partial=partial,
                     dict_class=self.dict_class,
                     index_errors=self.opts.index_errors,
+                    iterator=self.get_marshalling_iterator(),
                 )
             except ValidationError as error:
                 result = error.data

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -436,6 +436,7 @@ class BaseSchema(base.SchemaABC):
                     accessor=self.get_attribute,
                     dict_class=self.dict_class,
                     index_errors=self.opts.index_errors,
+                    iterator=self.get_marshalling_iterator(),
                     **kwargs
                 )
             except ValidationError as error:

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -16,7 +16,7 @@ from decimal import Decimal, ROUND_HALF_EVEN, Context, Inexact
 from email.utils import formatdate, parsedate
 from pprint import pprint as py_pprint
 
-from marshmallow.compat import binary_type, text_type
+from marshmallow.compat import binary_type, text_type, iteritems
 
 
 dateutil_available = False
@@ -404,3 +404,7 @@ def get_func_args(func):
 
 def if_none(value, default):
     return value if value is not None else default
+
+
+def iterate_fields_dict(data, fields_dict):
+    return iteritems(fields_dict)


### PR DESCRIPTION
jsonschema (also swagger) has the option, additionalProperties.

on schema definition like this. (this is swagger doc)

```yaml
definitions:
  person:
    type: object
    properties:
      name:
        type: string
    additionalPropeties: int
    required:
      - name
```

then.

```
{"name": "foo", "x": 20, "y": 10}
```

should return the value like this.

```
{"name": "foo", "x": 20, "y": 10}
```
